### PR TITLE
Remove use_2to3 to shut up setuptools 58+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,6 @@ setup(
     download_url = 'https://github.com/danthedeckie/simpleeval/tarball/' + __version__,
     keywords = ['eval', 'simple', 'expression', 'parse', 'ast'],
     test_suite = 'test_simpleeval',
-    use_2to3 = True,
     classifiers = ['Development Status :: 4 - Beta',
                    'Intended Audience :: Developers',
                    'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
Not the best commit message I've ever written, but hey, it's something... something yea no it's bad.

Anyway, IIRC setuptools was not just complaining about the deprecated (or removed?) `use_2to3` but I think even preventing the easy installation it via setuptools?

I'll gladly do some research and amend the commit with a better commit description if you want